### PR TITLE
Adding run number tracking and corresponding file naming convention

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,7 @@ file(GLOB DataHandlerHEADERS DataFormat.hpp DataHandler.hpp DataWriterHDF5.hpp D
 file(GLOB DataHandlerSOURCES uuid.cpp)
 add_library(DataHandler ${DataHandlerHEADERS} ${DataHandlerSOURCES} Waveform.hpp)
 
-add_executable(jadaq ${DataHandlerHEADERS} jadaq.cpp caen.hpp Configuration.cpp Configuration.hpp Digitizer.cpp Digitizer.hpp FunctionID.hpp FunctionID.cpp ini_parser.hpp StringConversion.cpp StringConversion.hpp CAENConf.cpp CAENConf.hpp trace.hpp interrupt.hpp container.hpp)
+add_executable(jadaq ${DataHandlerHEADERS} jadaq.cpp caen.hpp Configuration.cpp Configuration.hpp Digitizer.cpp Digitizer.hpp FunctionID.hpp FunctionID.cpp ini_parser.hpp StringConversion.cpp StringConversion.hpp CAENConf.cpp CAENConf.hpp trace.hpp interrupt.hpp container.hpp runno.cpp)
 target_link_libraries(jadaq ${CAEN_LIB} caen DataHandler ${Boost_LIBRARIES} pthread ${HDF5_CXX_LIBRARIES})
 
 # For jadaq-ds

--- a/DataWriterHDF5.hpp
+++ b/DataWriterHDF5.hpp
@@ -31,7 +31,6 @@
 #include <vector>
 #include <set>
 #include <cassert>
-#include "uuid.hpp"
 #include <H5Cpp.h>
 #include "DataFormat.hpp"
 #include "container.hpp"
@@ -64,9 +63,11 @@ private:
 
 
 public:
-    DataWriterHDF5(uuid runID)
+  DataWriterHDF5(std::string pathname, std::string runID)
     {
-        std::string filename = "jadaq-run-" + runID.toString() + ".h5";
+        if (!pathname.empty() && *pathname.rbegin() != '/')
+          pathname += '/';
+        std::string filename = pathname + "jadaq-run-" + runID + ".h5";
         try
         {
             file = new H5::H5File(filename, H5F_ACC_TRUNC);

--- a/DataWriterNetwork.hpp
+++ b/DataWriterNetwork.hpp
@@ -30,7 +30,6 @@
 #include <boost/asio.hpp>
 #include <boost/asio/io_service.hpp>
 #include <boost/bind.hpp>
-#include "uuid.hpp"
 #include "DataFormat.hpp"
 #include "container.hpp"
 
@@ -39,13 +38,13 @@ using boost::asio::ip::udp;
 class DataWriterNetwork
 {
 private:
-    uuid runID;
+    uint64_t runID;
     boost::asio::io_service ioService;
     udp::endpoint remoteEndpoint;
     udp::socket *socket = nullptr;
 
 public:
-    DataWriterNetwork(const std::string& address, const std::string& port, uuid runID_)
+    DataWriterNetwork(const std::string& address, const std::string& port, uint64_t runID_)
             : runID(runID_)
     {
         try {
@@ -73,7 +72,7 @@ public:
     void operator()(const jadaq::buffer<E>* buffer, uint32_t digitizerID, uint64_t globalTimeStamp)
     {
         Data::Header* header = (Data::Header*)buffer->data();
-        header->runID = runID.value();
+        header->runID = runID;
         header->globalTime = globalTimeStamp;
         header->digitizerID = digitizerID;
         header->version = Data::currentVersion;

--- a/DataWriterText.hpp
+++ b/DataWriterText.hpp
@@ -29,7 +29,6 @@
 #include <iomanip>
 #include <mutex>
 #include <cassert>
-#include "uuid.hpp"
 #include "DataFormat.hpp"
 #include "container.hpp"
 
@@ -40,9 +39,11 @@ private:
     std::mutex mutex;
 
 public:
-    DataWriterText(uuid runID)
+  DataWriterText(std::string pathname, std::string runID)
     {
-        std::string filename = "jadaq-run-" + runID.toString() + ".txt";
+        if (!pathname.empty() && *pathname.rbegin() != '/')
+          pathname += '/';
+        std::string filename = pathname + "jadaq-run-" + runID + ".txt";
         file = new std::fstream(filename,std::fstream::out);
         if (!file->is_open())
         {

--- a/jadaq.cpp
+++ b/jadaq.cpp
@@ -198,15 +198,15 @@ int main(int argc, const char *argv[])
     DataWriter dataWriter;
     if (conf.hdf5out)
     {
-        dataWriter = new DataWriterHDF5(runID);
+      dataWriter = new DataWriterHDF5(*conf.path, runNumber.toString());
     }
     else if (conf.textout)
     {
-        dataWriter = new DataWriterText(runID);
+      dataWriter = new DataWriterText(*conf.path, runNumber.toString());
     }
     else if(conf.network != nullptr)
     {
-        dataWriter = new DataWriterNetwork(*conf.network,*conf.port,runID);
+      dataWriter = new DataWriterNetwork(*conf.network,*conf.port,runID.value());
     }
     else if (conf.nullout)
     {

--- a/jadaq.cpp
+++ b/jadaq.cpp
@@ -185,7 +185,7 @@ int main(int argc, const char *argv[])
     std::ofstream  dst(dstName.str(), std::ios::binary);
     dst << src.rdbuf();
     if (!dst){
-      std::cerr << "Error: could not copy config file to " << *conf.path;
+      std::cerr << "Error: could not copy config file to '" << *conf.path << "' -- please check the output path argument!" << std::endl;
       return -1;
     }
     // write out next run number to file

--- a/runno.cpp
+++ b/runno.cpp
@@ -1,0 +1,59 @@
+/**
+ * jadaq (Just Another DAQ)
+ *
+ * @section LICENSE
+ * This program is free software: you can redistribute it and/or modify
+ *        it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ *         but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @section DESCRIPTION
+ * class for handling a run number and storing it to disk
+ *
+ */
+
+#include "runno.hpp"
+#include <fstream>
+
+bool runno::readFromPath(std::string pathname){
+  // load runno from file 'run.no' inside specified path
+  if (!pathname.empty() && *pathname.rbegin() != '/')
+    pathname += '/';
+  std::string fname = pathname+"run.no";
+  std::ifstream file(fname.c_str(), std::ifstream::in);
+  std::string result;
+  if (file.is_open()) {
+    std::getline(file, result);
+    if (file.fail()) {
+      throw std::runtime_error("Error reading run number from file " + fname);
+    }
+    // update value
+    val = std::stoi(result);
+  } else {
+    // could not open file
+    return false;
+  }
+  return true;
+}
+
+void runno::writeToPath(std::string pathname){
+  // writes runno value to 'run.no' file in the specified path
+  if (!pathname.empty() && *pathname.rbegin() != '/')
+    pathname += '/';
+  std::string fname = pathname+"run.no";
+  std::ofstream file(fname.c_str(), std::ifstream::out);
+  if (!file.is_open())
+    throw std::runtime_error("Unable to open file " + fname + " for writing run number");
+  file << val << std::endl;
+  if (file.fail())
+    throw std::runtime_error("Error writing run number to file " + fname);
+}
+

--- a/runno.hpp
+++ b/runno.hpp
@@ -1,0 +1,51 @@
+/**
+ * jadaq (Just Another DAQ)
+ *
+ * @section LICENSE
+ * This program is free software: you can redistribute it and/or modify
+ *        it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ *         but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @section DESCRIPTION
+ * class for handling a run number and storing it to disk
+ *
+ */
+#ifndef JADAQ_RUNNO_HPP
+#define JADAQ_RUNNO_HPP
+
+#include <cstdint>
+#include <iostream>
+#include <sstream>
+#include <iomanip>
+
+class runno {
+private:
+  uint64_t val;
+  uint8_t width;
+public:
+  runno() : val(0), width(5) {}
+  runno(uint64_t v): val(v), width(5) {}
+  uint64_t value() const {return val;}
+  void setWidth(uint8_t w){width=w;}
+  runno& operator=(const runno& that) {val = that.value(); return *this;}
+  runno& operator++() { val++; return *this; }
+  bool readFromPath(std::string pathname);
+  void writeToPath(std::string pathname);
+  std::string toString() const {
+    std::stringstream ss;
+    ss << std::setfill('0') << std::setw(width) << val;
+    return ss.str();
+  }
+};
+
+
+#endif


### PR DESCRIPTION
These commits add a output path argument to JADAQ and a run number that is being tracked for each individual directory. The run number is used to name each file and automatically incremented.

Additionally, the current config file is copied to the location of the output directory and named in the same way as the data file.